### PR TITLE
Small memory fix by strlcat in Accelerant.cpp

### DIFF
--- a/accelerant/Accelerant.cpp
+++ b/accelerant/Accelerant.cpp
@@ -265,7 +265,7 @@ void NvAccelerant::GetCloneInfo(void* data)
 {
 	debug_printf("NvAccelerant::GetCloneInfo\n");
 
-	strcpy((char*)data, kCloneInfo);
+	strlcpy((char*)data, kCloneInfo, CloneInfoSize());
 }
 
 void NvAccelerant::Clone(void* data)


### PR DESCRIPTION
Replace with strlcpy in `NvAccelerant::GetCloneInfo` function