### PR TITLE
Fix DisplayPort display detection

### DIFF
--- a/accelerant/Accelerant.cpp
+++ b/accelerant/Accelerant.cpp
@@ -225,6 +225,7 @@ NVDpyId NvAccelerant::FindConnectedDisplay(NVDpyIdList validDpys)
 		params.request.deviceHandle = fKmsDev.Get();
 		params.request.dispHandle = fDisp;
 		params.request.dpyId = curDpyId;
+		params.request.forceConnected = true;
 		CheckErrno(fKms.Control(NVKMS_IOCTL_QUERY_DPY_DYNAMIC_DATA, &params, sizeof(params)));
 		if (params.reply.connected || params.reply.edid.valid) {
 			break;


### PR DESCRIPTION
## Summary
- Add forceConnected=true to NVKMS_IOCTL_QUERY_DPY_DYNAMIC_DATA request
- Fixes display detection on DisplayPort connections

## Test Environment
- RTX 3080 Ti (GA102)
- 2560x1440 @ 165Hz DisplayPort

## Test Plan
- [x] Display detected on DisplayPort
- [x] Mode switching works correctly