### PR TITLE
Fix DMA buffer allocation to respect contiguous flag

### DIFF
--- a/nvidia_gsp/nvidia/os-haiku.cpp
+++ b/nvidia_gsp/nvidia/os-haiku.cpp
@@ -418,7 +418,7 @@ NV_STATUS NV_API_CALL nv_alloc_pages(
 	alloc->area.SetTo(create_area(
 		"DMA Buffer",
 		&address, B_ANY_KERNEL_ADDRESS, (uint64)page_count * B_PAGE_SIZE,
-		(true || contiguous) ? B_CONTIGUOUS : B_FULL_LOCK,
+		contiguous ? B_CONTIGUOUS : B_FULL_LOCK,
 		B_KERNEL_READ_AREA | B_KERNEL_WRITE_AREA | B_CLONEABLE_AREA
 	));
 


### PR DESCRIPTION
## Summary
- Remove debug code that forced all DMA allocations to be physically contiguous
- Fixes `NV_ERR_NO_MEMORY` (0x51) errors when allocating large GPU memory buffers

## Problem
The condition `(true || contiguous)` always evaluated to true, forcing all DMA buffer allocations to request physically contiguous memory via `B_CONTIGUOUS`. Finding large contiguous physical memory blocks is difficult, especially on systems with fragmented memory.

## Solution
Change to `contiguous ? B_CONTIGUOUS : B_FULL_LOCK` to respect the caller's request.

## Testing
- Tested with Llama 3.1 8B (4.5GB Q4_K_M) model via llama.cpp + NVK Vulkan
- Previously failed with `vk::Device::allocateMemory: ErrorOutOfDeviceMemory`
- Now loads and runs successfully at ~2 tokens/second on RTX 3080 Ti
- GPU properly boosts to 1965 MHz, 100% utilization during inference

## Hardware
- NVIDIA RTX 3080 Ti
- Haiku OS with nvidia_gsp driver